### PR TITLE
allow other users to connect to server

### DIFF
--- a/microbot.py
+++ b/microbot.py
@@ -130,6 +130,7 @@ class MicroBotPush:
 
         s.bind(self.socket_path)
         s.listen(1)
+        os.chmod(self.socket_path, 0o777)
         while True:
             self.connect()
 


### PR DESCRIPTION
If server is started with `microbot` user (as a service, for instance) clients get

```
Traceback (most recent call last):
  File "/opt/microbot/microbot.py", line 400, in <module>
    main()
  File "/opt/microbot/microbot.py", line 385, in main
    mbp.connect()
  File "/opt/microbot/microbot.py", line 88, in connect
    self.socket = self.__connectToServer()
  File "/opt/microbot/microbot.py", line 112, in __connectToServer
    self.socket.connect(self.socket_path)
PermissionError: [Errno 13] Permission denied

```

Allow other users to interact with the socket